### PR TITLE
dsk_dsk.cpp: sectors must be read even if it contains Deleted Mark

### DIFF
--- a/src/lib/formats/dsk_dsk.cpp
+++ b/src/lib/formats/dsk_dsk.cpp
@@ -420,12 +420,12 @@ bool dsk_format::load(io_generic *io, uint32_t form_factor, floppy_image *image)
 				else
 					sects[j].actual_size = 128 << tr.sector_size_code;
 
-				if (sector.fdc_status_reg1 == 0xb2 || (sector.fdc_status_reg2 & 0x40))
+				if (sector.fdc_status_reg2 & 0x40)
 					sects[j].deleted = 1;
-				if (sector.fdc_status_reg1 == 0xb5 || (sector.fdc_status_reg2 & 0x20))
+				if ((sector.fdc_status_reg1 & 0x20) || (sector.fdc_status_reg2 & 0x20))
 					sects[j].bad_crc = 1;
 
-				if(!sects[j].deleted) {
+				if(!(sector.fdc_status_reg1 & 0x04)) {
 					sects[j].data = sect_data + sdatapos;
 					io_generic_read(io, sects[j].data, pos, sects[j].actual_size);
 					sdatapos += sects[j].actual_size;


### PR DESCRIPTION
FDC will read the data if SK bit is not set.

Fixes MameTesters bug #07081